### PR TITLE
Allow eventData to be passed to $.fn.bind

### DIFF
--- a/tappy.js
+++ b/tappy.js
@@ -61,11 +61,11 @@
 
 	// monkeybind
 	var oldBind = $.fn.bind;
-	$.fn.bind = function( evt, callback ){
+	$.fn.bind = function( evt ){
 		if( /(^| )tap( |$)/.test( evt ) ){
 			tap( this );
 		}
-		return oldBind.apply( this, [evt, callback] );
+		return oldBind.apply( this, arguments );
 	};
 
 }( this, jQuery ));


### PR DESCRIPTION
The way that `oldBind` is currently being called does not allow the usage of bind's optional middle argument,  `eventData`. Though not commonly used, I've encountered it in legacy code. This change will make the monkey-patched version of bind work the way jQuery's does.

http://api.jquery.com/bind/
