### PR TITLE
Don't block other click handlers

### DIFF
--- a/tappy.js
+++ b/tappy.js
@@ -13,7 +13,14 @@
 				scrollTolerance = 15;
 
 			function trigger( e ){
-				$( e.target ).trigger( "tap", [ e, $( e.target ).attr( "href" ) ] );
+				var $target = $( e.target ),
+					href = $target.attr( "href" );
+
+				$target
+					.trigger( "tap", [ e, href ] )
+					// this click should not cause another call to trigger
+					.trigger( "click", [ e, href, false ] );
+
 				e.stopImmediatePropagation();
 			}
 
@@ -49,7 +56,10 @@
 				}
 
 				w.tapHandling = e.type;
-				trigger( e );
+				// if the last argument is false, this is the click we triggered, so don't trigger again
+				if (arguments[arguments.length - 1] !== false) {
+					trigger( e );
+				}
 			}
 
 			$el

--- a/tappy.js
+++ b/tappy.js
@@ -78,4 +78,4 @@
 		return oldBind.apply( this, [evt, callback] );
 	};
 
-}( this, jQuery ));
+}( window, jQuery ));


### PR DESCRIPTION
This keeps Tappy from preventing other click handlers that might be bound to something. On a current project, for example, we have an analytics script that attaches a click handler to any element with a certain class. Tappy was preventing that click handler from being called.

This change makes `trigger` trigger a `click` event, but passes an extra argument that `end` then checks for, so that it doesn't get stuck in a loop. The current implementation is a little greasy, and could probably use a some refactoring to be clearer as to the function of passing `false` around.
