### PR TITLE
Re-added e.stopImmediatePropagation();

### DIFF
--- a/tappy.js
+++ b/tappy.js
@@ -17,6 +17,7 @@
 
 			function trigger( e ){
 				$( e.target ).trigger( "tap", [ e, $( e.target ).attr( "href" ) ] );
+				e.stopImmediatePropagation();
 			}
 
 			function getCoords( e ){

--- a/tappy.js
+++ b/tappy.js
@@ -64,7 +64,9 @@
 					return;
 				}
 
-				e.preventDefault();
+				if (!$(e.target).closest('#virtualKeyboard').length) {
+				    e.preventDefault();
+				}
 
 				// this part prevents a double callback from touch and mouse on the same tap
 


### PR DESCRIPTION
When this line is deleted, the events are triggered as many times as 'tap' events are registered.